### PR TITLE
Prevent editing tasks being draggable

### DIFF
--- a/app/javascript/controllers/drag_and_drop_controller.js
+++ b/app/javascript/controllers/drag_and_drop_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
       delay: 100,
       delayOnTouchOnly: true,
       touchStartThreshold: 10,
+      filter: ".sortable-ignore",
 
       onEnd: (event) => {
         const taskId = event.item.dataset.taskId

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "turbo_frame_task_#{@task.id}" do %>
-  <%= form_with(model: [@task], class:"p-2 flex flex-col") do |f| %>
+  <%= form_with(model: [@task], class:"p-2 flex flex-col sortable-ignore") do |f| %>
     <div>
       <%= f.label :title, class: '' %>
       <%= f.text_field :title, class: 'rounded border-gray-400 mb-2 w-full', placeholder: 'Title' %>


### PR DESCRIPTION
By setting a filter class on SortableJS and applying it on the edit form. Fixes #7 